### PR TITLE
Using path.sep as the path separetor to work on mac os.

### DIFF
--- a/lib/hexo-azure-blob-deployer.js
+++ b/lib/hexo-azure-blob-deployer.js
@@ -48,13 +48,14 @@ module.exports = function(args, configFile) {
 
 			var rootPath = configFile.public_dir;
 			var files = [];
+			var pathcomponent = require('path');
 
 			var getFiles = function(path, subpath, files) {			
 				fs.readdirSync(path).forEach(function(file)
 				{
 					if(!!file && file[0] == '.') return;
 					
-					var fileName = path + '\\' + file;
+					var fileName = path + pathcomponent.sep + file;
 		
 					if(fs.lstatSync(fileName).isDirectory())
 					{
@@ -62,7 +63,7 @@ module.exports = function(args, configFile) {
 					} 
 					else 
 					{										
-						var blobName = subpath.replace(rootPath,"").split("\\").join("/")  + '/' + file;
+						var blobName = subpath.replace(rootPath,"").split(pathcomponent.sep).join("/")  + '/' + file;
 						
 						var obj = {
 							"file": fileName,


### PR DESCRIPTION
Error occurs on Mac OS Sierra, because path separator of Windows OS '\\' is used.