### PR TITLE
Bug fix. Subdirectories are not correctly reflected on Azure blob.

### DIFF
--- a/lib/hexo-azure-blob-deployer.js
+++ b/lib/hexo-azure-blob-deployer.js
@@ -55,15 +55,15 @@ module.exports = function(args, configFile) {
 				{
 					if(!!file && file[0] == '.') return;
 					
-					var fileName = path + pathcomponent.sep + file;
+					var fileName = pathcomponent.join(path, subpath, file);
 		
 					if(fs.lstatSync(fileName).isDirectory())
 					{
-						getFiles(fileName, path, files);
+						getFiles(fileName, "", files);
 					} 
 					else 
 					{										
-						var blobName = subpath.replace(rootPath,"").split(pathcomponent.sep).join("/")  + '/' + file;
+						var blobName = pathcomponent.relative(rootPath, fileName).replace(pathcomponent.sep, "/");
 						
 						var obj = {
 							"file": fileName,


### PR DESCRIPTION
=before=
{
  "file": "public/js/bootstrap.min.js",
  "subpath": "public",
  "blobName": "/bootstrap.min.js"
},
{
  "file": "public/js/gallery.js",
  "subpath": "public",
  "blobName": "/gallery.js"
},

=fixed=
{
  "file": "public/js/bootstrap.min.js",
  "subpath": "",
  "blobName": "js/bootstrap.min.js"
},
{
  "file": "public/js/gallery.js",
  "subpath": "",
  "blobName": "js/gallery.js"
},